### PR TITLE
sepolicy: Use the real path for sysfs nodes instead of symlinks

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,2 +1,2 @@
-/sys/devices/virtual/input/max1187x/glove -- u:object_r:sysfs_touch:s0
-/sys/devices/virtual/input/max1187x/power/wakeup -- u:object_r:sysfs_touch:s0
+/sys/devices/f9964000.i2c/i2c-8/8-0048/glove -- u:object_r:sysfs_touch:s0
+/sys/devices/f9964000.i2c/i2c-8/8-0048/power/wakeup -- u:object_r:sysfs_touch:s0


### PR DESCRIPTION
Change-Id: Ia8caf4e08445ba3e3db84181891efb5828609ac7